### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git checkout -b seuNome
 ````bash
 git add .
 
-git comit -m "sua mensagem de commit"
+git commit -m "sua mensagem de commit"
 
 git checkout main
 


### PR DESCRIPTION
Typo fixed in the README.md file:
`git comit` -> `git commit`